### PR TITLE
Fix an issue while calling onTap: close #8

### DIFF
--- a/lib/src/interactive_chart.dart
+++ b/lib/src/interactive_chart.dart
@@ -212,9 +212,10 @@ class _InteractiveChartState extends State<InteractiveChart> {
             }),
             onTapCancel: () => setState(() => _tapPosition = null),
             onTapUp: (_) {
-              setState(() => _tapPosition = null);
-              // Fire callback event (if needed)
+              // Fire callback event (if onTap() is available)
+              // call _fireOnTapEvent() before assigning null on _tapPosition
               if (widget.onTap != null) _fireOnTapEvent();
+              setState(() => _tapPosition = null);
             },
             // Pan and zoom
             onScaleStart: (details) => _onScaleStart(details.localFocalPoint),


### PR DESCRIPTION
## Summary
- #8 onTap is not working as described

## Problems
https://github.com/fluttercandies/flutter-interactive-chart/blob/8bce5d633379995685b4a2351d8a5f9f81955997/lib/src/interactive_chart.dart#L214-L218
- _fireOnTapEvent() needs position information to get a position of a candle.
- But assignment of null on _tapPosition inside setState() make it unavailable.

## Expected Results
![image](https://user-images.githubusercontent.com/48780754/145377744-549f3898-c7d8-4c3e-8eb9-c4e1203ea952.png)
- make onTap() work. 