### PR TITLE
extra info in onTap event

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,7 +89,7 @@ class _MyAppState extends State<MyApp> {
             //   "Lo": "${candle.low?.toStringAsFixed(2)}",
             // },
             /** Callbacks */
-            // onTap: (candle) => print("user tapped on $candle"),
+            // onTap: (candle, candleIndex, price) => print("user tapped on $candle at \$$price"),
             // onCandleResize: (width) => print("each candle is $width wide"),
           ),
         ),

--- a/lib/src/chart_painter.dart
+++ b/lib/src/chart_painter.dart
@@ -207,6 +207,28 @@ class ChartPainter extends CustomPainter {
           ..strokeWidth = max(params.candleWidth * 0.88, 1.0)
           ..color = params.style.selectionHighlightColor);
     canvas.restore();
+    // Draw price line
+    canvas.drawLine(
+        Offset(0, pos.dy),
+        Offset(params.chartWidth, pos.dy),
+        Paint()
+          ..strokeWidth = 1
+          ..color = params.style.selectionHighlightColor);
+    // Draw price label
+    final priceTp = TextPainter(
+      text: TextSpan(
+        text: getPriceLabel(params.getPriceFromOffset(pos.dy)),
+        style: params.style.priceLabelStyle,
+      ),
+    )
+      ..textDirection = TextDirection.ltr
+      ..layout();
+    priceTp.paint(
+        canvas,
+        Offset(
+          params.chartWidth + 4,
+          pos.dy - priceTp.height / 2,
+        ));
     // Draw info pane
     _drawTapInfoOverlay(canvas, params, candle);
   }

--- a/lib/src/interactive_chart.dart
+++ b/lib/src/interactive_chart.dart
@@ -53,7 +53,7 @@ class InteractiveChart extends StatefulWidget {
   final OverlayInfoGetter? overlayInfo;
 
   /// An optional event, fired when the user clicks on a candlestick.
-  final ValueChanged<CandleData>? onTap;
+  final void Function(CandleData, int, double)? onTap;
 
   /// An optional event, fired when user zooms in/out.
   ///
@@ -338,9 +338,11 @@ class _InteractiveChartState extends State<InteractiveChart> {
     if (_prevParams == null || _tapPosition == null) return;
     final params = _prevParams!;
     final dx = _tapPosition!.dx;
+    final dy = _tapPosition!.dy;
     final selected = params.getCandleIndexFromOffset(dx);
     final candle = params.candles[selected];
-    widget.onTap?.call(candle);
+    final price = params.getPriceFromOffset(dy);
+    widget.onTap?.call(candle, selected, price);
   }
 }
 

--- a/lib/src/painter_params.dart
+++ b/lib/src/painter_params.dart
@@ -53,6 +53,9 @@ class PainterParams {
     return i;
   }
 
+  double getPriceFromOffset(double y) =>
+      (priceHeight - y) / priceHeight * (maxPrice - minPrice) + minPrice;
+
   double fitPrice(double y) =>
       priceHeight * (maxPrice - y) / (maxPrice - minPrice);
 


### PR DESCRIPTION
-add price info to onTap event
-add horizontal price highlight line on tap

Example of extra info shown when tapping:
![image](https://user-images.githubusercontent.com/42459/214746420-e7f07aeb-dd35-4fea-a8e0-0a0f3526d7be.png)
