### PR TITLE
Unnecessary import blocking publishing action

### DIFF
--- a/lib/src/chart_painter.dart
+++ b/lib/src/chart_painter.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 import 'candle_data.dart';
 import 'painter_params.dart';


### PR DESCRIPTION
Please approve to unblock publishing action

########## Publish Log

Package validation found the following potential issue:
* `dart analyze` found the following issue(s):
  Analyzing lib, pubspec.yaml...
  
     info - lib/src/chart_painter.dart:4:8 - The import of 'package:flutter/widgets.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart'. Try removing the import directive. - unnecessary_import
  
  1 issue found.

Package has 1 warning.
pub finished with exit code 65