### PR TITLE
Keep the last X-axis offset when adding new candles to the beginning of the list

### DIFF
--- a/lib/src/interactive_chart.dart
+++ b/lib/src/interactive_chart.dart
@@ -101,6 +101,16 @@ class _InteractiveChartState extends State<InteractiveChart> {
   PainterParams? _prevParams; // used in onTapUp event
 
   @override
+  void didUpdateWidget(covariant InteractiveChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.candles.length < widget.candles.length) {
+      // Change offset to show the latest candle when new data is added
+      _startOffset =
+          max(0, widget.candles.length * _candleWidth - _prevChartWidth!);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {


### PR DESCRIPTION
This will allow the previous period chart to be loaded and displayed correctly when the X axis offset reaches the zero end.